### PR TITLE
I've completed the refactor to move the LLM client initialization int…

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,9 @@
 import os
 from flask import Flask
+import google.generativeai as genai
+import openai
+import anthropic
+from perplexipy import PerplexityClient
 
 def create_app(test_config=None):
     """Create and configure an instance of the Flask application."""
@@ -8,6 +12,10 @@ def create_app(test_config=None):
     # Set default configuration
     app.config.from_mapping(
         SECRET_KEY='dev', # Change this for production
+        GEMINI_API_KEY = os.environ.get('GEMINI_API_KEY'),
+        OPENAI_API_KEY = os.environ.get('OPENAI_API_KEY'),
+        ANTHROPIC_API_KEY = os.environ.get('ANTHROPIC_API_KEY'),
+        PERPLEXITY_API_KEY = os.environ.get('PERPLEXITY_API_KEY'),
     )
 
     if test_config is None:
@@ -22,6 +30,30 @@ def create_app(test_config=None):
         os.makedirs(app.instance_path)
     except OSError:
         pass
+
+    # --- LLM Client Initialization ---
+    # Store clients in a dictionary on the app object
+    app.llm_clients = {}
+
+    # Configure Gemini
+    if app.config['GEMINI_API_KEY']:
+        genai.configure(api_key=app.config['GEMINI_API_KEY'])
+        # The genai library uses a global configuration, but we can
+        # store the model object for convenience.
+        app.llm_clients['gemini'] = genai.GenerativeModel('gemini-1.5-flash-latest')
+
+    # Configure OpenAI
+    if app.config['OPENAI_API_KEY']:
+        app.llm_clients['openai'] = openai.OpenAI(api_key=app.config['OPENAI_API_KEY'])
+
+    # Configure Anthropic
+    if app.config['ANTHROPIC_API_KEY']:
+        app.llm_clients['anthropic'] = anthropic.Anthropic(api_key=app.config['ANTHROPIC_API_KEY'])
+
+    # Configure Perplexity
+    if app.config['PERPLEXITY_API_KEY']:
+        app.llm_clients['perplexity'] = PerplexityClient(app.config['PERPLEXITY_API_KEY'])
+
 
     with app.app_context():
         # Import and register the dashboard blueprint


### PR DESCRIPTION
…o the app factory. Here's a breakdown of my changes:

*   I moved the initialization of the LLM clients (Gemini, OpenAI, Anthropic, Perplexity) from the `dashboard` blueprint to the `create_app` application factory.
*   The initialized clients are now stored on the `app.llm_clients` dictionary, making them accessible throughout your application via the `current_app` context.
*   This improves the modularity of your application by decoupling the blueprints from the client configuration and initialization process. It also makes the application easier for you to test and configure.
*   I also updated the `dashboard` blueprint to retrieve the clients from `current_app.llm_clients`.